### PR TITLE
no-popups plugin

### DIFF
--- a/src/l10n/en.json
+++ b/src/l10n/en.json
@@ -122,5 +122,7 @@
   "plugins.statistics.title": "Status Bar",
   "plugins.statistics.description": "Count the number of blocks and file size of the project",
   "plugins.statistics.option.countCodeNum": "Count code lines",
-  "plugins.statistics.option.projectSize": "Measure project size"
+  "plugins.statistics.option.projectSize": "Measure project size",
+  "plugins.noPopups.title":"Disable alert popups"
+
 }

--- a/src/l10n/zh-cn.json
+++ b/src/l10n/zh-cn.json
@@ -122,5 +122,7 @@
   "plugins.statistics.title": "统计栏",
   "plugins.statistics.description": "统计工程文件的代码数量和文件大小。",
   "plugins.statistics.option.countCodeNum": "统计代码数量",
-  "plugins.statistics.option.projectSize": "统计工程大小"
+  "plugins.statistics.option.projectSize": "统计工程大小",
+  "plugins.noPopups.title":"禁止alert弹窗"
+
 }

--- a/src/plugins-entry.ts
+++ b/src/plugins-entry.ts
@@ -9,4 +9,5 @@ export default {
   "dropdown-searchable": () => import(/* webpackChunkName: "plugin-dropdown-searchable" */ "src/plugins/dropdown-searchable"),
   statistics: () => import(/* webpackChunkName: "plugin-statistics" */ "src/plugins/statistics"),
   "historical-version": () => import(/* webpackChunkName: "plugin-historical-version" */ "src/plugins/historical-version"),
+  "no-popups": () => import(/* webpackChunkName: "plugin-no-popups" */ "src/plugins/no-popups"),
 } as const;

--- a/src/plugins-manifest.ts
+++ b/src/plugins-manifest.ts
@@ -9,4 +9,5 @@ export default {
   "dropdown-searchable": () => import(/* webpackChunkName: "plugin-dropdown-searchable-manifest" */ "src/plugins/dropdown-searchable/manifest"),
   statistics: () => import(/* webpackChunkName: "plugin-statistics-manifest" */ "src/plugins/statistics/manifest"),
   "historical-version": () => import(/* webpackChunkName: "plugin-historical-version-manifest" */ "src/plugins/historical-version/manifest"),
+  "no-popups": () => import(/* webpackChunkName: "plugin-no-popups-manifest" */ "src/plugins/no-popups/manifest"),
 } as const;

--- a/src/plugins/no-popups/index.js
+++ b/src/plugins/no-popups/index.js
@@ -1,0 +1,44 @@
+// @author: 多bug的啸天犬 @ CCW
+// @date: 2021-04-25
+// @version: 1.0.0
+// @description: 禁止弹窗-插件
+// @homepage: https://github.com/MoreBugOfDog/gandi-plugins/tree/main/src/plugins/no-popups
+// @bugs: https://github.com/MoreBugOfDog/gandi-plugins/issues
+// @license: MPL-2.0
+// 这个插件的思路是，由于很多工程都使用了YUEN的系统信息拓展制作alert弹窗，但是测试时一般
+// 不会想被打断，这样在编辑器内禁止alert弹窗，会增强编辑体验。
+// 关闭插件，会恢复alert弹窗。
+// 这个更改无法使用控制台测试，请使用YUEN的系统信息拓展。
+
+const NoPopups = (context) => {
+  
+  // 恢复被覆写的alert的函数
+  function getAlert(){
+    　　var f = document.createElement("iframe");
+    　　f.style.cssText = "border:0;width:0;height:0;display:none";
+    　　document.body.appendChild(f);
+    　　var d = f.contentWindow.document;
+    　　d.write("<script type=\"text/javascript\">window.parent.alert = alert;<\/script>");
+    　　d.close();
+    }
+  function noAlert(){
+    // 覆写alert，使其弹窗功能失效 
+    window.alert = () => {
+        return false;
+    }
+  } 
+  noAlert();
+  
+  
+  return {
+    dispose: () => {
+      /** Remove some side effects */
+      // 恢复Alert
+      getAlert();
+    },
+  };
+};
+
+
+export default NoPopups;
+

--- a/src/plugins/no-popups/manifest.ts
+++ b/src/plugins/no-popups/manifest.ts
@@ -1,0 +1,25 @@
+export default {
+  name: "no-popups",
+  type: "function",
+  description: "覆写alert()暴力禁止弹出窗口",
+  credits: [
+    {
+      name: "多bug的啸天犬",
+    },
+    {
+      name: "https",
+    },
+    {
+      name: "ccw",
+    },
+    {
+      name: "site",
+    },
+    {
+      name: "student",
+    },
+    {
+      name: "197354885",
+    },
+  ],
+};

--- a/src/plugins/plugins-manager/index.tsx
+++ b/src/plugins/plugins-manager/index.tsx
@@ -8,6 +8,7 @@ import { LoadingPlugins } from "src/plugins-controller";
 const ALL_PLUGINS = Object.keys(Plugins);
 // When the line numbers of the variables below change, plopfile.js needs to be updated.
 const DEFAULT_INJECT_PLUGINS = [
+  "no-popups",
   "folder",
   "statistics",
   "terminal",


### PR DESCRIPTION
// @author: 多bug的啸天犬 @ CCW
// @date: 2021-04-25
// @version: 1.0.0
// @description: 禁止弹窗-插件
// @homepage: https://github.com/MoreBugOfDog/gandi-plugins/tree/main/src/plugins/no-popups
// @bugs: https://github.com/MoreBugOfDog/gandi-plugins/issues
// @license: MPL-2.0
// 这个插件的思路是，由于很多工程都使用了YUEN的系统信息拓展制作alert弹窗，但是测试时一般
// 不会想被打断，这样在编辑器内禁止alert弹窗，会增强编辑体验。
// 关闭插件，会恢复alert弹窗。
// 这个更改无法使用控制台测试，请使用YUEN的系统信息拓展。

第一次写插件，如有错误请见谅。
已经经过测试，但是由于当前脚手架的Gandi版本较久，无法测试作者显示模块，如有错误还麻烦帮忙修正，谢谢。
