### PR TITLE
fix: Fix offset issue in plugin popup during drag

### DIFF
--- a/src/components/ExpansionBox/index.tsx
+++ b/src/components/ExpansionBox/index.tsx
@@ -79,6 +79,7 @@ const ExpansionBox = forwardRef<ExpansionBoxRef, ExpansionBoxProps>((props, ref)
   const containerNodeInfo = React.useRef(containerInfo);
   const client = React.useRef({ x: 0, y: 0 });
   const bounds = React.useRef({ top: 60, left: 72 });
+  const interlayer = React.useRef<HTMLDivElement | null>(null);
 
   const handleBringToFront = React.useCallback(() => {
     const minIndex = typeof zIndex === "undefined" ? 101 : zIndex;
@@ -117,6 +118,18 @@ const ExpansionBox = forwardRef<ExpansionBoxRef, ExpansionBoxProps>((props, ref)
     container.current.style.userSelect = "none";
   };
 
+  const handleDragStart = React.useCallback(() => {
+    if (interlayer.current) {
+      interlayer.current.remove();
+      interlayer.current = null;
+    }
+    if (container.current.parentNode) {
+      interlayer.current = document.createElement("div");
+      interlayer.current.className = styles.interlayer;
+      container.current.parentNode.insertBefore(interlayer.current, container.current);
+    }
+  }, []);
+
   const handleDragStop = React.useCallback(
     (_: unknown, data: { x: number; y: number }) => {
       const verifiedData = verifyTranslate(data);
@@ -127,6 +140,10 @@ const ExpansionBox = forwardRef<ExpansionBoxRef, ExpansionBoxProps>((props, ref)
       containerNodeInfo.current.translateX = verifiedData.x;
       containerNodeInfo.current.translateY = verifiedData.y;
       onSizeChange({ ...containerNodeInfo.current });
+      if (interlayer.current) {
+        interlayer.current.remove();
+        interlayer.current = null;
+      }
     },
     [onSizeChange],
   );
@@ -236,7 +253,13 @@ const ExpansionBox = forwardRef<ExpansionBoxRef, ExpansionBoxProps>((props, ref)
   }, [borderRadius]);
 
   return (
-    <Draggable position={position} bounds={bounds.current} onStop={handleDragStop} handle={"." + id}>
+    <Draggable
+      position={position}
+      bounds={bounds.current}
+      onStart={handleDragStart}
+      onStop={handleDragStop}
+      handle={"." + id}
+    >
       <div
         className={classNames(styles.container, className)}
         ref={container}

--- a/src/components/ExpansionBox/styles.less
+++ b/src/components/ExpansionBox/styles.less
@@ -122,3 +122,13 @@
   right: -1px;
   cursor: nwse-resize;
 }
+
+.interlayer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  z-index: 100;
+}


### PR DESCRIPTION
Fixed an issue where the popup did not follow the mouse properly due to other events being triggered during fast dragging, causing a position offset. Refs #78