### PR TITLE
fix(data-category-tweaks): 修复 getBlocksXML 覆盖与其他扩展的链条冲突及 TDZ 报错

### DIFF
--- a/src/plugins/data-category-tweaks/index.tsx
+++ b/src/plugins/data-category-tweaks/index.tsx
@@ -9,6 +9,11 @@ const DataCategoryTweaks: React.FC<PluginContext> = ({ vm, blockly, workspace, m
     let hasSeparateLocalVariables = false;
     let hasMoveReportersDown = false;
     let style: HTMLStyleElement | null = null;
+
+    // TDZ
+    const runtime = vm.runtime as any;
+    const ScratchBlocks = blockly;
+    
     const setHasSeparateListCategory = (value: boolean) => {
       if (value) {
         style = document.createElement("style");
@@ -22,6 +27,10 @@ const DataCategoryTweaks: React.FC<PluginContext> = ({ vm, blockly, workspace, m
         style.remove();
       }
       hasSeparateListCategory = value;
+
+      if (runtime && runtime.__dataCategoryTweaksState) {
+        runtime.__dataCategoryTweaksState.hasSeparateListCategory = value;
+      }
     };
 
     const register = registerSettings(
@@ -74,8 +83,8 @@ const DataCategoryTweaks: React.FC<PluginContext> = ({ vm, blockly, workspace, m
       <DataCategoryTweaksIcon />,
     );
 
-    const runtime = vm.runtime as any;
-    const ScratchBlocks = blockly;
+    // const runtime = vm.runtime as any;
+    // const ScratchBlocks = blockly;
 
     const SMALL_GAP = 8;
     const BIG_GAP = 24;

--- a/src/plugins/data-category-tweaks/index.tsx
+++ b/src/plugins/data-category-tweaks/index.tsx
@@ -232,43 +232,56 @@ const DataCategoryTweaks: React.FC<PluginContext> = ({ vm, blockly, workspace, m
     // https://github.com/scratchfoundation/scratch-gui/blob/ddd2fa06f2afa140a46ec03be91796ded861e65c/src/containers/blocks.jsx#L344
     // https://github.com/scratchfoundation/scratch-gui/blob/2ceab00370ad7bd8ecdf5c490e70fd02152b3e2a/src/lib/make-toolbox-xml.js#L763
     // https://github.com/scratchfoundation/scratch-vm/blob/a0c11d6d8664a4f2d55632e70630d09ec6e9ae28/src/engine/runtime.js#L1381
-    const originalGetBlocksXML = runtime.getBlocksXML;
-    runtime.getBlocksXML = function (target) {
-      const result = originalGetBlocksXML.call(this, target);
+    if (!runtime.__dataCategoryTweaksState) {
+      runtime.__dataCategoryTweaksState = {
+        hasSeparateListCategory: false,
+        enabled: true
+      };
+    }
+    const state = runtime.__dataCategoryTweaksState;
 
-      if (hasSeparateListCategory) {
-        result.push({
-          id: "data",
-          xml: `
-          <category
-            name="%{BKY_CATEGORY_VARIABLES}"
-            id="variables"
-            iconURI="${VariablesIcon}"
-            colour="${ScratchBlocks.Colours.data.primary}"
-            secondaryColour="${ScratchBlocks.Colours.data.tertiary}"
-            custom="VARIABLE">
-          </category>
-          <category
-            name="${msg("plugins.dataCategoryTweaks.list")}"
-            id="lists"
-            iconURI="${ListIcon}"
-            colour="${ScratchBlocks.Colours.data_lists.primary}"
-            secondaryColour="${ScratchBlocks.Colours.data_lists.tertiary}"
-            custom="LIST">
-          </category>`,
-        });
-        result.map = (callback) => {
-          // Prevent Scratch from trying to change the color of the added category in high contrast mode.
-          // https://github.com/scratchfoundation/scratch-gui/blob/44eb578/src/containers/blocks.jsx#L358-L361
-          // https://github.com/scratchfoundation/scratch-gui/blob/44eb578/src/lib/themes/blockHelpers.js#L18-L53
-          return Array.prototype.map.call(result, (extension) => {
-            if (extension.id === "data") return extension;
-            else return callback(extension);
+    state.hasSeparateListCategory = hasSeparateListCategory;
+    state.enabled = true;
+
+    if (!runtime.__dataCategoryTweaksWrapped) {
+      runtime.__dataCategoryTweaksWrapped = true;
+      const originalGetBlocksXML = runtime.getBlocksXML;
+      
+      runtime.getBlocksXML = function (target) {
+        const result = originalGetBlocksXML.call(this, target);
+
+        if (state.enabled && state.hasSeparateListCategory) {
+          result.push({
+            id: "data",
+            xml: `
+            <category
+              name="%{BKY_CATEGORY_VARIABLES}"
+              id="variables"
+              iconURI="${VariablesIcon}"
+              colour="${ScratchBlocks.Colours.data.primary}"
+              secondaryColour="${ScratchBlocks.Colours.data.tertiary}"
+              custom="VARIABLE">
+            </category>
+            <category
+              name="${msg("plugins.dataCategoryTweaks.list")}"
+              id="lists"
+              iconURI="${ListIcon}"
+              colour="${ScratchBlocks.Colours.data_lists.primary}"
+              secondaryColour="${ScratchBlocks.Colours.data_lists.tertiary}"
+              custom="LIST">
+            </category>`,
           });
-        };
-      }
-      return result;
-    };
+          result.map = (callback) => {
+            // Prevent Scratch from trying to change the color of the added category in high contrast mode.
+            return Array.prototype.map.call(result, (extension) => {
+              if (extension.id === "data") return extension;
+              else return callback(extension);
+            });
+          };
+        }
+        return result;
+      };
+    }
 
     // If editingTarget is set, the editor has already rendered and we have to tell it to rerender.
     if (vm.editingTarget) {
@@ -282,10 +295,16 @@ const DataCategoryTweaks: React.FC<PluginContext> = ({ vm, blockly, workspace, m
       setHasSeparateListCategory(false);
       hasSeparateLocalVariables = false;
       hasMoveReportersDown = false;
+      
+      if (runtime.__dataCategoryTweaksState) {
+        runtime.__dataCategoryTweaksState.hasSeparateListCategory = false;
+        runtime.__dataCategoryTweaksState.enabled = false; 
+      }
+
       if (shouldEmitWorkspaceUpdate) vm.emitWorkspaceUpdate();
       if (shouldRefreshToolboxSelection) workspace.refreshToolboxSelection_();
       // Restore an overridden function to its original implementation.
-      runtime.getBlocksXML = originalGetBlocksXML;
+      // runtime.getBlocksXML = originalGetBlocksXML;
       ScratchBlocks.Flyout.prototype.show = oldShow;
 
       register.dispose();

--- a/src/plugins/data-category-tweaks/manifest.ts
+++ b/src/plugins/data-category-tweaks/manifest.ts
@@ -11,5 +11,9 @@ export default {
       name: "fath11@Cocrea",
       link: "https://cocrea.world/@Fath11",
     },
+    {
+      name: "XiaoChen004Hao@CCW",
+      link: "https://www.ccw.site/student/247111583",
+    },
   ],
 };


### PR DESCRIPTION
### 下面的PR文档由GLM-5.2撰写，我只在里面添加了一些细节信息，并且其中的“测试验证”部分我都做了一遍，确认无误

## 问题背景
`Data category tweaks` 插件对 `runtime.getBlocksXML` 采用了"覆盖 + cleanup 恢复"的模式。这在独立使用时正常，但与同样拦截该方法的第三方扩展(如：[Vapor 3D](https://github.com/JoyFul721/Vapor3D/))共存时存在两个问题：
### 问题 1：调用链断裂导致其他扩展失效
如果第三方扩展在本插件**之后**加载并包装 `runtime.getBlocksXML`，当本插件因设置切换、语言切换或卸载触发 `useEffect` cleanup 时，会执行：
```js
runtime.getBlocksXML = originalGetBlocksXML;
```
这会强制把 `getBlocksXML` 恢复成本插件加载时的原生函数，**把后加载扩展的包装层从调用链中踢掉**，导致其自定义分类静默消失、折叠/嵌套分类失效。
### 问题 2：切换语言时 TDZ 报错
`runtime` 的 `const` 声明原本位于 `registerSettings(...)` 调用之后。但框架在 `registerSettings` 内部会**同步回填**已保存的开关值，立即触发 `onChange` → `setHasSeparateListCategory`，而该函数引用了 `runtime`。此时 `runtime` 尚处于暂时性死区（TDZ），抛出：
```
ReferenceError: Cannot access 'runtime' before initialization
```
该问题在扩展先于插件加载时更容易触发（时序差异使 `emitWorkspaceUpdate` 的回填点暴露）。
## 解决方案
### 1. flag 模式替代覆盖-恢复（修复问题 1）
- 对 `runtime.getBlocksXML` **只包装一次**，用 `runtime.__dataCategoryTweaksWrapped` 标记防止重复包装。
- 用持久化状态对象 `runtime.__dataCategoryTweaksState` 存储 `{ enabled, hasSeparateListCategory }`。
- 包装函数内部读取 state 决定是否注入分类；禁用时作为透传层直接转发。
- cleanup 中**不再恢复 `getBlocksXML`**，仅设 `state.enabled = false`。
这样无论插件如何切换/卸载，`getBlocksXML` 调用链永远不断裂，后加载扩展的包装层始终安全挂在链上。
### 2. `runtime` 声明上移（修复问题 2）
将 `const runtime = vm.runtime as any;` 从 `registerSettings(...)` 之后移到 `useEffect` 开头、`setHasSeparateListCategory` 定义之前，确保回填触发 onChange 时 `runtime` 已完成初始化。
### 3. `setHasSeparateListCategory` 同步 state
在 `setHasSeparateListCategory` 中将最新值同步到 `runtime.__dataCategoryTweaksState.hasSeparateListCategory`，使开关切换实时反映到包装函数。
## 调用链示意
修改前（cleanup 切断链条）：
```
pluginWrapper → extWrapper → 原生
                     ↑ cleanup 后被踢掉
pluginWrapper → 原生（extWrapper 丢失）
```
修改后（链条永不断裂）：
```
pluginWrapper(透传) → extWrapper → 原生   ✓
```
## 测试验证
- [x] 开启/关闭"分离列表分类"，显示效果正常
- [x] 开启/关闭"分离局部变量"、"下沉 reporter"，效果正常
- [x] 禁用插件后，分离的分类正确合并回去，功能完全停止
- [x] 重新启用插件，功能恢复
- [x] 切换界面语言，插件不再报 TDZ 错误，分类状态保持
- [x] 加载一个同样覆盖 `getBlocksXML` 的扩展（嵌套折叠分类）：
  - 扩展后加载：切换/禁用本插件，扩展分类不消失
  - 扩展先加载：切换语言，两者都正常工作
- [x] 同时开启本插件全部选项 + 扩展全部功能，切换语言无报错
## 兼容性
- 不改变插件的任何用户可见行为和设置项
- 对不拦截 `getBlocksXML` 的环境完全透明（flag 关闭时 wrapper 为透传层）
- `Flyout.prototype.show` 的覆盖保持原样（未观察到与其他扩展冲突，如需可后续单独处理）